### PR TITLE
Implemented store-based text-level CSS toggling

### DIFF
--- a/src/cite-services/components/Reader.vue
+++ b/src/cite-services/components/Reader.vue
@@ -20,7 +20,7 @@
 
           <pagination :prev="passageLink(query, passage.prev)" :next="passageLink(query, passage.next)" :title="passage.title"></pagination>
 
-          <div id="text" :class="'textSize-' + this.textSize">
+          <div id="text" :class="textClasses">
             <div v-for="node in passage.text.Nodes">
               {{ node.text }}
             </div>
@@ -103,7 +103,7 @@ export default {
       query: null,
     };
   },
-  computed: mapGetters(['user', 'passage', 'textSize']),
+  computed: mapGetters(['user', 'passage', 'textClasses']),
   watch: {
     $route: 'fetchData',
   },
@@ -234,15 +234,6 @@ export default {
     clear: both;
     word-spacing: 0.3em;
     color: #333;
-    &.textSize-small {
-      font-size: 14pt;
-    }
-    &.textSize-normal {
-      font-size: 16pt;
-    }
-    &.textSize-large {
-      font-size: 20pt;
-    }
   }
 
   /* widgets */
@@ -271,18 +262,6 @@ export default {
         list-style-type: none;
         margin: 0;
         padding: 0;
-      }
-      .textSize-small {
-        font-family: $main-font-family;
-        font-size: 14pt;
-      }
-      .textSize-normal {
-        font-family: $main-font-family;
-        font-size: 16pt;
-      }
-      .textSize-large {
-        font-family: $main-font-family;
-        font-size: 20pt;
       }
     }
     &:hover {

--- a/src/components/TextFormatting.vue
+++ b/src/components/TextFormatting.vue
@@ -14,15 +14,18 @@
   import Widget from '@/components/Widget';
 
   export default {
+    created() {
+      this.normalText();
+    },
     methods: {
       smallerText() {
-        this.$store.commit('setTextSize', 'small');
+        this.$store.commit('setTextClass', { textSize: 'small' });
       },
       normalText() {
-        this.$store.commit('setTextSize', 'normal');
+        this.$store.commit('setTextClass', { textSize: 'normal' });
       },
       largerText() {
-        this.$store.commit('setTextSize', 'large');
+        this.$store.commit('setTextClass', { textSize: 'large' });
       },
     },
     components: {
@@ -32,12 +35,39 @@
 </script>
 
 <style lang="scss" scoped>
+  @import "../styles/common.scss";
   .click {
     color: inherit;
     text-decoration: none;
     cursor: pointer;
     &:hover {
       color: #666;
+    }
+  }
+  .textSize-small {
+    font-family: $main-font-family;
+    font-size: 14pt;
+  }
+  .textSize-normal {
+    font-family: $main-font-family;
+    font-size: 16pt;
+  }
+  .textSize-large {
+    font-family: $main-font-family;
+    font-size: 20pt;
+  }
+</style>
+
+<style lang="scss">
+  #text {
+    &.textSize-small {
+      font-size: 14pt;
+    }
+    &.textSize-normal {
+      font-size: 16pt;
+    }
+    &.textSize-large {
+      font-size: 20pt;
     }
   }
 </style>

--- a/src/cts/components/Reader.vue
+++ b/src/cts/components/Reader.vue
@@ -22,7 +22,7 @@
 
           <pagination :prev="passageLink(query, passage.prev)" :next="passageLink(query, passage.next)" :title="passage.title"></pagination>
 
-          <div id="text" :class="'textSize-' + this.textSize"></div>
+          <div id="text" :class="textClasses"></div>
 
           <pagination :prev="passageLink(query, passage.prev)" :next="passageLink(query, passage.next)" :title="passage.title"></pagination>
 
@@ -106,7 +106,7 @@ export default {
       query: null,
     };
   },
-  computed: mapGetters(['user', 'passage', 'textSize', 'ctsTextGroup', 'ctsWork']),
+  computed: mapGetters(['user', 'passage', 'textSize', 'ctsTextGroup', 'ctsWork', 'textClasses']),
   watch: {
     $route: 'fetchData',
     passage: 'updateReader',
@@ -252,15 +252,6 @@ export default {
     word-spacing: 0.3em;
     line-height: 1.6;
     color: #333;
-    &.textSize-small {
-      font-size: 14pt;
-    }
-    &.textSize-normal {
-      font-size: 16pt;
-    }
-    &.textSize-large {
-      font-size: 20pt;
-    }
   }
 
   /* TEI */
@@ -308,18 +299,6 @@ export default {
         list-style-type: none;
         margin: 0;
         padding: 0;
-      }
-      .textSize-small {
-        font-family: $main-font-family;
-        font-size: 14pt;
-      }
-      .textSize-normal {
-        font-family: $main-font-family;
-        font-size: 16pt;
-      }
-      .textSize-large {
-        font-family: $main-font-family;
-        font-size: 20pt;
       }
     }
     &:hover {

--- a/src/morphgnt/components/Reader.vue
+++ b/src/morphgnt/components/Reader.vue
@@ -23,7 +23,7 @@
 
           <pagination :prev="passageLink(query, passage.prev)" :next="passageLink(query, passage.next)" :title="passage.title"></pagination>
 
-          <div id="text" :class="'textSize-' + this.textSize + (this.colour ? ' colour-' + this.colour : '')">
+          <div id="text" :class="textClasses">
             <p>
               <div class="word unit" v-for="(word, index) in passage.words" @click="handleWordSelect(word)">
                 <span class="verse-num" v-if="word['@id'].slice(-8, -5) == '001'">{{ parseInt(word['@id'].slice(-11, -8)) }}</span>
@@ -129,7 +129,7 @@ export default {
       books: [],
     };
   },
-  computed: mapGetters(['user', 'book', 'passage', 'textSize', 'interlinear', 'colour']),
+  computed: mapGetters(['user', 'book', 'passage', 'textClasses', 'interlinear']),
   watch: {
     $route: 'fetchData',
   },
@@ -202,9 +202,7 @@ export default {
 <style lang="scss">
 
   /* variables */
-
-  $main-font-family: "Skolar";
-  $widget-font-family: "PT Sans", $main-font-family;
+  @import "../../styles/common.scss";
 
   /* hover opacity */
 
@@ -283,15 +281,6 @@ export default {
         font-size: 60%;
       }
     }
-    &.textSize-small {
-      font-size: 14pt;
-    }
-    &.textSize-normal {
-      font-size: 16pt;
-    }
-    &.textSize-large {
-      font-size: 20pt;
-    }
 
     div.unit {
       display: inline-block;
@@ -304,32 +293,6 @@ export default {
       display: inline-block;
       font-size: 75%;
       color: gray;
-    }
-
-    &.colour-pos {
-      .pos-N, .pos-A {
-        color: #C00;
-      }
-      .pos-RA, .pos-RD, .pos-RI, .pos-RP, .pos-RR {
-        color: #C50;
-      }
-      .pos-V {
-        color: #00C;
-      }
-    }
-    &.colour-case {
-      .case-N {
-        color: #C00;
-      }
-      .case-G {
-        color: #9C6;
-      }
-      .case-D {
-        color: #6CC;
-      }
-      .case-A {
-        color: #FC0;
-      }
     }
 
     .freq-0 {
@@ -393,18 +356,6 @@ export default {
         list-style-type: none;
         margin: 0;
         padding: 0;
-      }
-      .textSize-small {
-        font-family: $main-font-family;
-        font-size: 14pt;
-      }
-      .textSize-normal {
-        font-family: $main-font-family;
-        font-size: 16pt;
-      }
-      .textSize-large {
-        font-family: $main-font-family;
-        font-size: 20pt;
       }
     }
     &:hover {

--- a/src/morphgnt/components/TextColouring.vue
+++ b/src/morphgnt/components/TextColouring.vue
@@ -16,13 +16,13 @@
   export default {
     methods: {
       noColour() {
-        this.$store.commit('setColour', null);
+        this.$store.commit('setTextClass', { colour: false });
       },
       posColour() {
-        this.$store.commit('setColour', 'pos');
+        this.$store.commit('setTextClass', { colour: 'pos' });
       },
       caseColour() {
-        this.$store.commit('setColour', 'case');
+        this.$store.commit('setTextClass', { colour: 'case' });
       },
     },
     components: {
@@ -38,6 +38,36 @@
     cursor: pointer;
     &:hover {
       color: #666;
+    }
+  }
+</style>
+
+<style lang="scss">
+  #text {
+    &.colour-pos {
+      .pos-N, .pos-A {
+        color: #C00;
+      }
+      .pos-RA, .pos-RD, .pos-RI, .pos-RP, .pos-RR {
+        color: #C50;
+      }
+      .pos-V {
+        color: #00C;
+      }
+    }
+    &.colour-case {
+      .case-N {
+        color: #C00;
+      }
+      .case-G {
+        color: #9C6;
+      }
+      .case-D {
+        color: #6CC;
+      }
+      .case-A {
+        color: #FC0;
+      }
     }
   }
 </style>

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -26,12 +26,11 @@ export default new Vuex.Store({
     user: null,
     book: null,
     interlinear: false,
-    colour: null,
     ctsURL: 'http://cts.perseids.org/api/cts/',
     ctsTextGroup: '',
     ctsWork: '',
     passage: null,
-    textSize: 'normal',
+    textClasses: {},
   },
   getters: {
     user: state => state.user,
@@ -40,9 +39,18 @@ export default new Vuex.Store({
     ctsTextGroup: state => state.ctsTextGroup,
     ctsWork: state => state.ctsWork,
     passage: state => state.passage,
-    textSize: state => state.textSize,
     interlinear: state => state.interlinear,
-    colour: state => state.colour,
+    textClasses(state) {
+      return Object.entries(state.textClasses).reduce(
+        (o, [k, v]) => {
+          if (typeof v === 'boolean') {
+            return Object.assign(o, { [k]: v });
+          }
+          return Object.assign(o, { [`${k}-${v}`]: true });
+        },
+        {},
+      );
+    },
   },
   mutations: {
     setUser(state, user) {
@@ -62,14 +70,11 @@ export default new Vuex.Store({
       state.book = null;
       state.passage = passage;
     },
-    setTextSize(state, size) {
-      state.textSize = size;
-    },
     toggleInterlinear(state) {
       state.interlinear = !state.interlinear;
     },
-    setColour(state, scheme) {
-      state.colour = scheme;
+    setTextClass(state, classes) {
+      state.textClasses = { ...state.textClasses, ...classes };
     },
     ...firebaseMutations,
   },

--- a/src/styles/common.scss
+++ b/src/styles/common.scss
@@ -1,0 +1,2 @@
+$main-font-family: "Skolar";
+$widget-font-family: "PT Sans", $main-font-family;


### PR DESCRIPTION
In addition to the new CSS toggling, I have cleaned up some CSS
duplication and enabled the TextFormatting widget to dictate the
reader styling.

Fixes #4 