### PR TITLE
Fixed rendering on passage on first load

### DIFF
--- a/src/cts/components/Reader.vue
+++ b/src/cts/components/Reader.vue
@@ -161,11 +161,9 @@ export default {
     },
   },
   directives: {
-    fragment: {
-      update(el, binding) {
-        el.innerHTML = '';
-        el.appendChild(binding.value);
-      },
+    fragment(el, binding) {
+      el.innerHTML = '';
+      el.appendChild(binding.value);
     },
   },
   components: {


### PR DESCRIPTION
The behavior bind and update of the fragment directive need to be
identical. This change uses the directive shorthand to accomplish
it without duplicating code.

Fixes #1