### PR TITLE
don't wrap KWIC contexts

### DIFF
--- a/src/morphgnt/components/Kwic.vue
+++ b/src/morphgnt/components/Kwic.vue
@@ -54,6 +54,7 @@ export default {
     width: 100%;
     .pre {
       text-align: right;
+      white-space: nowrap;
     }
     .keyword {
       white-space: nowrap;
@@ -62,6 +63,7 @@ export default {
     }
     .post {
       text-align: left;
+      white-space: nowrap;
     }
   }
 </style>


### PR DESCRIPTION
looks much better if the pre/post contents in KWIC widgets don't wrap. This does mean the content is sometimes wider than the widget and so has a horizontal scroll bar but I think that's fine.

(Incidentally, the KWIC widget is a good candidate for a "main panel" version too) for #20 